### PR TITLE
feat: add Anthropic/Claude as optional LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,12 @@ TINYFISH_API_KEY="your_tinyfish_api_key_here"
 
 # OpenRouter API — free tier available at https://openrouter.ai
 OPENROUTER_API_KEY="your_openrouter_api_key_here"
-OPENROUTER_MODEL="nvidia/nemotron-3-super-120b-a12b:free"
-OPENROUTER_FALLBACK_MODELS="google/gemma-4-31b-it:free,google/gemma-4-26b-a4b-it:free,meta-llama/llama-3.3-70b-instruct:free"
+OPENROUTER_MODEL="meta-llama/llama-3.3-70b-instruct:free"
+OPENROUTER_FALLBACK_MODELS="nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free,qwen/qwen3-coder:free"
+
+# Anthropic / Claude (optional — alternative to OpenRouter)
+# Set llm_provider=anthropic in config.json to use Claude instead of OpenRouter
+# ANTHROPIC_API_KEY="your_anthropic_api_key_here"
 
 # Telegram Notification (optional — create bot via @BotFather)
 TELEGRAM_TOKEN="your_telegram_bot_token_here"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# autopilot-jobs
+# autopilot-jobhunt
 
 AI job agent: scans 130+ company careers pages nightly, scores every role against your resume with an LLM (0–100), sends top matches via Telegram, and drafts tailored cover letters + resume bullets on demand.
 
@@ -49,11 +49,11 @@ See [SETUP.md §7](SETUP.md#step-7--register-with-claude-code-mcp) for the full 
 
 Quick reference:
 ```bash
-claude mcp add autopilot-jobs \
+claude mcp add autopilot-jobhunt \
   --env TINYFISH_API_KEY=your_key \
   --env OPENROUTER_API_KEY=your_key \
   -- python -m job_hunt.mcp_server
-# Then add "cwd": "/path/to/autopilot-jobs" in ~/.claude.json
+# Then add "cwd": "/path/to/autopilot-jobhunt" in ~/.claude.json
 ```
 
 MCP tools exposed: `scan_jobs`, `draft_application(job_ref)`, `export_jobs(min_score, days)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to autopilot-jobs
+# Contributing to autopilot-jobhunt
 
 Thanks for wanting to contribute. Here's what's most useful:
 
@@ -45,8 +45,8 @@ If you find the LLM scores inaccurately, open an issue with:
 ## Development setup
 
 ```bash
-git clone https://github.com/tarunlnmiit/autopilot-jobs.git
-cd autopilot-jobs
+git clone https://github.com/tarunlnmiit/autopilot-jobhunt.git
+cd autopilot-jobhunt
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 ```

--- a/README.md
+++ b/README.md
@@ -32,12 +32,28 @@ On demand:
 
 ---
 
+## Usage modes
+
+```
+Mode 1: Standalone CLI (no Claude Code required)
+  pip install autopilot-jobs
+  autopilot scan / autopilot draft 1 / autopilot export
+
+Mode 2: Claude Code MCP (control via natural language)
+  pip install 'autopilot-jobs[mcp]'
+  claude mcp add autopilot-jobs ...
+  → "Scan for ML jobs" / "Draft application for job #2"
+```
+
+Both modes use the same config and produce the same output.
+
 ## Quick start
 
 ```bash
 git clone https://github.com/tarunlnmiit/autopilot-jobs.git
 cd autopilot-jobs
-pip install -e '.[mcp]'
+pip install -e '.'               # standalone CLI
+# pip install -e '.[mcp]'       # + Claude Code MCP integration
 cp config.example.json config.json && cp .env.example .env
 # Fill in your API keys and candidate profile, then:
 autopilot scan
@@ -174,9 +190,11 @@ autopilot-jobs/
 
 ---
 
-## LLM models used (all free)
+## LLM options
 
-The tool uses [OpenRouter](https://openrouter.ai) with a fallback chain of free models:
+### Default: OpenRouter (free)
+
+Uses a 4-model fallback chain — all free, no credit card needed:
 
 | Model | Role |
 |---|---|
@@ -185,7 +203,25 @@ The tool uses [OpenRouter](https://openrouter.ai) with a fallback chain of free 
 | `google/gemma-4-31b-it:free` | Fallback 2 |
 | `qwen/qwen3-coder:free` | Fallback 3 |
 
-If one model hits its daily free-tier quota, the tool automatically tries the next. **Zero LLM cost by default.** A nightly scan uses ~5–15 LLM calls total (jobs scored in batches).
+If one model hits its daily free-tier quota, the tool automatically tries the next. **Zero LLM cost by default.**
+
+### Alternative: Claude (Anthropic)
+
+If you have an Anthropic API key or Claude Pro:
+
+```bash
+pip install 'autopilot-jobs[claude]'
+```
+
+In `config.json`:
+
+```json
+"llm_provider": "anthropic",
+"anthropic_api_key": "sk-ant-...",
+"anthropic_model": "claude-haiku-4-5-20251001"
+```
+
+`claude-haiku-4-5-20251001` is fast and cheap; `claude-sonnet-4-6` gives higher quality scores. A nightly scan uses ~5–15 LLM calls total (jobs scored in batches of 10).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autopilot-jobs
+# autopilot-jobhunt
 
 **Your AI job agent. Finds, scores, and drafts applications — while you sleep.**
 
@@ -6,10 +6,10 @@
 
 <!-- Add demo GIF here after recording: ![Demo](demo/demo.gif) -->
 
-[![PyPI version](https://img.shields.io/pypi/v/autopilot-jobs)](https://pypi.org/project/autopilot-jobs/)
+[![PyPI version](https://img.shields.io/pypi/v/autopilot-jobhunt)](https://pypi.org/project/autopilot-jobhunt/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![GitHub Stars](https://img.shields.io/github/stars/tarunlnmiit/autopilot-jobs?style=social)](https://github.com/tarunlnmiit/autopilot-jobs/stargazers)
+[![GitHub Stars](https://img.shields.io/github/stars/tarunlnmiit/autopilot-jobhunt?style=social)](https://github.com/tarunlnmiit/autopilot-jobhunt/stargazers)
 
 **[📖 Full setup guide with Claude Code MCP integration → SETUP.md](SETUP.md)**
 
@@ -36,12 +36,12 @@ On demand:
 
 ```
 Mode 1: Standalone CLI (no Claude Code required)
-  pip install autopilot-jobs
+  pip install autopilot-jobhunt
   autopilot scan / autopilot draft 1 / autopilot export
 
 Mode 2: Claude Code MCP (control via natural language)
-  pip install 'autopilot-jobs[mcp]'
-  claude mcp add autopilot-jobs ...
+  pip install 'autopilot-jobhunt[mcp]'
+  claude mcp add autopilot-jobhunt ...
   → "Scan for ML jobs" / "Draft application for job #2"
 ```
 
@@ -50,8 +50,8 @@ Both modes use the same config and produce the same output.
 ## Quick start
 
 ```bash
-git clone https://github.com/tarunlnmiit/autopilot-jobs.git
-cd autopilot-jobs
+git clone https://github.com/tarunlnmiit/autopilot-jobhunt.git
+cd autopilot-jobhunt
 pip install -e '.'               # standalone CLI
 # pip install -e '.[mcp]'       # + Claude Code MCP integration
 cp config.example.json config.json && cp .env.example .env
@@ -73,13 +73,13 @@ autopilot scan
 
 ## Claude Code / MCP integration
 
-Use autopilot-jobs as an MCP server inside **Claude Code** (CLI) or **Claude Desktop**.
+Use autopilot-jobhunt as an MCP server inside **Claude Code** (CLI) or **Claude Desktop**.
 
 ### Step 1: Install with MCP support
 
 ```bash
-git clone https://github.com/tarunlnmiit/autopilot-jobs.git
-cd autopilot-jobs
+git clone https://github.com/tarunlnmiit/autopilot-jobhunt.git
+cd autopilot-jobhunt
 pip install -e '.[mcp]'
 ```
 
@@ -88,7 +88,7 @@ pip install -e '.[mcp]'
 **Option A — one command:**
 
 ```bash
-claude mcp add autopilot-jobs \
+claude mcp add autopilot-jobhunt \
   --env TINYFISH_API_KEY=your_key \
   --env OPENROUTER_API_KEY=your_key \
   --env TELEGRAM_TOKEN=your_token \
@@ -101,10 +101,10 @@ claude mcp add autopilot-jobs \
 ```json
 {
   "mcpServers": {
-    "autopilot-jobs": {
+    "autopilot-jobhunt": {
       "command": "python",
       "args": ["-m", "job_hunt.mcp_server"],
-      "cwd": "/absolute/path/to/autopilot-jobs",
+      "cwd": "/absolute/path/to/autopilot-jobhunt",
       "env": {
         "TINYFISH_API_KEY": "your_key",
         "OPENROUTER_API_KEY": "your_key",
@@ -170,7 +170,7 @@ Set `min_score` in config to filter. Default: 60.
 ## Project structure
 
 ```
-autopilot-jobs/
+autopilot-jobhunt/
 ├── job_hunt/
 │   ├── main.py          # CLI entry point
 │   ├── scanner.py       # Job discovery + LLM scoring
@@ -210,7 +210,7 @@ If one model hits its daily free-tier quota, the tool automatically tries the ne
 If you have an Anthropic API key or Claude Pro:
 
 ```bash
-pip install 'autopilot-jobs[claude]'
+pip install 'autopilot-jobhunt[claude]'
 ```
 
 In `config.json`:

--- a/SETUP.md
+++ b/SETUP.md
@@ -70,6 +70,37 @@ A nightly scan uses approximately **5–15 LLM calls** (jobs are scored in batch
 
 ---
 
+### Claude / Anthropic (optional — alternative to OpenRouter)
+
+<details>
+<summary>Use Claude as your LLM instead of OpenRouter — click to expand</summary>
+
+If you have an Anthropic API key or Claude Pro, you can skip OpenRouter entirely.
+
+1. Get an API key at [console.anthropic.com](https://console.anthropic.com)
+2. Install the Claude extra:
+   ```bash
+   pip install 'autopilot-jobs[claude]'
+   ```
+3. In `config.json`, set:
+   ```json
+   "llm_provider": "anthropic",
+   "anthropic_api_key": "sk-ant-...",
+   "anthropic_model": "claude-haiku-4-5-20251001"
+   ```
+
+Recommended models:
+- `claude-haiku-4-5-20251001` — fast and affordable, handles JSON scoring well
+- `claude-sonnet-4-6` — higher quality scores, higher cost
+
+> [!TIP]
+> Leave `openrouter_api_key` empty if using Claude — the field is ignored when
+> `llm_provider` is set to `"anthropic"`.
+
+</details>
+
+---
+
 ### Telegram (optional)
 
 <details>

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,4 @@
-# Setting Up autopilot-jobs
+# Setting Up autopilot-jobhunt
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org/)
 [![Free APIs](https://img.shields.io/badge/APIs-free%20tier-brightgreen)](#step-1--get-your-api-keys)
@@ -50,7 +50,7 @@ If Python is below 3.11, install via [pyenv](https://github.com/pyenv/pyenv) or 
 2. **Keys** → **Create key**
 3. Copy the key (starts with `sk-or-v1-…`)
 
-autopilot-jobs uses a 4-model fallback chain — all free:
+autopilot-jobhunt uses a 4-model fallback chain — all free:
 
 | Model | Role | Characteristic |
 |---|---|---|
@@ -80,7 +80,7 @@ If you have an Anthropic API key or Claude Pro, you can skip OpenRouter entirely
 1. Get an API key at [console.anthropic.com](https://console.anthropic.com)
 2. Install the Claude extra:
    ```bash
-   pip install 'autopilot-jobs[claude]'
+   pip install 'autopilot-jobhunt[claude]'
    ```
 3. In `config.json`, set:
    ```json
@@ -106,7 +106,7 @@ Recommended models:
 <details>
 <summary>Set up Telegram notifications — click to expand</summary>
 
-Telegram lets autopilot-jobs message you the top job matches immediately after each scan.
+Telegram lets autopilot-jobhunt message you the top job matches immediately after each scan.
 
 1. Open Telegram and message **@BotFather**
 2. Send `/newbot` and follow the prompts
@@ -126,14 +126,14 @@ You'll add both values to `.env` in Step 5.
 ## Step 2 — Clone and install
 
 ```bash
-git clone https://github.com/tarunlnmiit/autopilot-jobs.git
-cd autopilot-jobs
+git clone https://github.com/tarunlnmiit/autopilot-jobhunt.git
+cd autopilot-jobhunt
 pip install -e '.[mcp]'
 ```
 
 ✅ **Expected last line:**
 ```
-Successfully installed autopilot-jobs-0.1.0
+Successfully installed autopilot-jobhunt-0.1.0
 ```
 
 > [!NOTE]
@@ -235,7 +235,7 @@ If you see this, your install is working correctly — config loads, CLI is on y
 
 > [!NOTE]
 > If you see `autopilot: command not found`, re-run `pip install -e '.[mcp]'` from
-> inside the `autopilot-jobs` directory.
+> inside the `autopilot-jobhunt` directory.
 
 ---
 
@@ -247,7 +247,7 @@ If you see this, your install is working correctly — config loads, CLI is on y
 
 ### 7a — Get the absolute path to the repo
 
-Run this from inside the `autopilot-jobs` directory:
+Run this from inside the `autopilot-jobhunt` directory:
 
 ```bash
 pwd
@@ -255,7 +255,7 @@ pwd
 
 Example output:
 ```
-/Users/yourname/autopilot-jobs
+/Users/yourname/autopilot-jobhunt
 ```
 
 Copy this path — you'll need it in 7c.
@@ -267,7 +267,7 @@ Copy this path — you'll need it in 7c.
 **Option A: one command (then manually add `cwd` in 7c)**
 
 ```bash
-claude mcp add autopilot-jobs \
+claude mcp add autopilot-jobhunt \
   --env TINYFISH_API_KEY=sk-tinyfish-your-key \
   --env OPENROUTER_API_KEY=sk-or-v1-your-key \
   --env TELEGRAM_TOKEN=your_token \
@@ -285,10 +285,10 @@ Open `~/.claude.json` (create it if it doesn't exist) and add the block below un
 ```json
 {
   "mcpServers": {
-    "autopilot-jobs": {
+    "autopilot-jobhunt": {
       "command": "python",
       "args": ["-m", "job_hunt.mcp_server"],
-      "cwd": "/Users/yourname/autopilot-jobs",
+      "cwd": "/Users/yourname/autopilot-jobhunt",
       "env": {
         "TINYFISH_API_KEY": "sk-tinyfish-your-key",
         "OPENROUTER_API_KEY": "sk-or-v1-your-key",
@@ -304,13 +304,13 @@ Open `~/.claude.json` (create it if it doesn't exist) and add the block below un
 
 ### 7c — Set the working directory (required for Option A)
 
-If you used `claude mcp add` (Option A), open `~/.claude.json` and find the `autopilot-jobs` entry. Add the `"cwd"` field pointing to your repo path from Step 7a:
+If you used `claude mcp add` (Option A), open `~/.claude.json` and find the `autopilot-jobhunt` entry. Add the `"cwd"` field pointing to your repo path from Step 7a:
 
 ```json
-"autopilot-jobs": {
+"autopilot-jobhunt": {
   "command": "python",
   "args": ["-m", "job_hunt.mcp_server"],
-  "cwd": "/Users/yourname/autopilot-jobs",   // ← add this line
+  "cwd": "/Users/yourname/autopilot-jobhunt",   // ← add this line
   "env": { ... }
 }
 ```
@@ -323,7 +323,7 @@ If you used `claude mcp add` (Option A), open `~/.claude.json` and find the `aut
 claude mcp list
 ```
 
-✅ **Expected:** `autopilot-jobs` appears in the list.
+✅ **Expected:** `autopilot-jobhunt` appears in the list.
 
 If it doesn't appear, open a new terminal and try again — Claude Code picks up config changes on restart.
 
@@ -333,7 +333,7 @@ If it doesn't appear, open a new terminal and try again — Claude Code picks up
 
 Start a Claude Code session and say:
 
-> "List the tools available from autopilot-jobs"
+> "List the tools available from autopilot-jobhunt"
 
 Claude should respond with: `scan_jobs`, `draft_application`, `export_jobs`.
 
@@ -405,7 +405,7 @@ This adds a cron job that runs `autopilot scan` every day at 2:30 AM local time 
 
 To remove the cron job:
 ```bash
-crontab -e   # delete the autopilot-jobs line
+crontab -e   # delete the autopilot-jobhunt line
 ```
 
 </details>
@@ -427,7 +427,7 @@ crontab -e   # delete the autopilot-jobs line
 | `python3 --version` < 3.11 | Python too old | Install 3.11+ via [pyenv](https://github.com/pyenv/pyenv) |
 | MCP server not in `claude mcp list` | Config not reloaded | Open a new terminal and check again |
 
-Still stuck? [Open an issue](https://github.com/tarunlnmiit/autopilot-jobs/issues) with the error message and your Python version.
+Still stuck? [Open an issue](https://github.com/tarunlnmiit/autopilot-jobhunt/issues) with the error message and your Python version.
 
 </details>
 
@@ -438,4 +438,4 @@ Still stuck? [Open an issue](https://github.com/tarunlnmiit/autopilot-jobs/issue
 - Edit `companies.json` to add companies you want to target
 - Adjust `min_score` in `config.json` (60–70 is a good starting range)
 - After your first scan, try `autopilot draft 1` to generate your first cover letter
-- Star the repo if this saved you time → [github.com/tarunlnmiit/autopilot-jobs](https://github.com/tarunlnmiit/autopilot-jobs)
+- Star the repo if this saved you time → [github.com/tarunlnmiit/autopilot-jobhunt](https://github.com/tarunlnmiit/autopilot-jobhunt)

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
   "tinyfish_api_key": "YOUR_TINYFISH_API_KEY",
+  "llm_provider": "openrouter",
   "openrouter_api_key": "YOUR_OPENROUTER_API_KEY",
   "openrouter_model": "meta-llama/llama-3.3-70b-instruct:free",
   "openrouter_fallback_models": [
@@ -7,6 +8,8 @@
     "google/gemma-4-31b-it:free",
     "qwen/qwen3-coder:free"
   ],
+  "anthropic_api_key": "YOUR_ANTHROPIC_API_KEY",
+  "anthropic_model": "claude-haiku-4-5-20251001",
   "telegram": {
     "token": "YOUR_TELEGRAM_BOT_TOKEN",
     "chat_id": "YOUR_TELEGRAM_CHAT_ID"

--- a/demo/run_demo.sh
+++ b/demo/run_demo.sh
@@ -27,5 +27,5 @@ $DEMO_PYTHON "$DEMO_SCRIPT" export
 
 sleep 1
 echo ""
-echo "Done. Star the repo → github.com/tarunlnmiit/autopilot-jobs"
+echo "Done. Star the repo → github.com/tarunlnmiit/autopilot-jobhunt"
 sleep 2

--- a/job_hunt/drafter.py
+++ b/job_hunt/drafter.py
@@ -3,10 +3,9 @@ import re
 from datetime import datetime
 from pathlib import Path
 
-from openai import OpenAI
 from tinyfish import TinyFish
 
-from job_hunt.llm_utils import chat_with_fallback
+from job_hunt.llm_utils import chat_with_llm
 
 LAST_SCAN_FILE = Path("state/last_scan.json")
 OUTPUT_DIR = Path("output")
@@ -35,10 +34,6 @@ def _resolve_job(job_ref: str) -> tuple[str, str]:
 
 def draft_application(config: dict, job_ref: str) -> None:
     tf = TinyFish(api_key=config["tinyfish_api_key"])
-    llm = OpenAI(
-        api_key=config["openrouter_api_key"],
-        base_url="https://openrouter.ai/api/v1",
-    )
 
     cand = config.get("candidate", {})
     candidate_name = cand.get("name", "the candidate")
@@ -62,8 +57,8 @@ def draft_application(config: dict, job_ref: str) -> None:
 
     # 1. Tailored resume
     print("Tailoring resume...")
-    resume_md = chat_with_fallback(
-        llm, config,
+    resume_md = chat_with_llm(
+        config,
         messages=[{"role": "user", "content": f"""Rewrite the resume below to mirror the language and emphasized skills in this job description.
 
 Rules:
@@ -89,8 +84,8 @@ Output ONLY the tailored resume in Markdown. No preamble."""}],
     # 2. Cover letter
     print("Drafting cover letter...")
     relocation_line = f"- {relocation_note}" if relocation_note else ""
-    cover_md = chat_with_fallback(
-        llm, config,
+    cover_md = chat_with_llm(
+        config,
         messages=[{"role": "user", "content": f"""Write a one-page cover letter for {candidate_name} applying to this role.
 
 Rules:
@@ -117,8 +112,8 @@ Output ONLY the cover letter. No preamble."""}],
 
     # 3. Application info
     print("Extracting application info...")
-    info_txt = chat_with_fallback(
-        llm, config,
+    info_txt = chat_with_llm(
+        config,
         messages=[{"role": "user", "content": f"""Extract from this job posting (plain text output, clear labels):
 
 1. Application URL or email

--- a/job_hunt/llm_utils.py
+++ b/job_hunt/llm_utils.py
@@ -1,6 +1,48 @@
+import os
 import time
 
 from openai import OpenAI, RateLimitError
+
+
+def _make_openrouter_client(config: dict) -> OpenAI:
+    return OpenAI(
+        api_key=config.get("openrouter_api_key") or os.getenv("OPENROUTER_API_KEY"),
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+
+def _chat_with_anthropic(config: dict, messages: list[dict], temperature: float, max_tokens: int) -> str:
+    try:
+        import anthropic
+    except ImportError:
+        raise ImportError("Run: pip install 'autopilot-jobs[claude]'")
+    api_key = config.get("anthropic_api_key") or os.getenv("ANTHROPIC_API_KEY")
+    model = config.get("anthropic_model", "claude-haiku-4-5-20251001")
+    client = anthropic.Anthropic(api_key=api_key)
+    system = next((m["content"] for m in messages if m["role"] == "system"), None)
+    user_msgs = [m for m in messages if m["role"] != "system"]
+    kwargs: dict = {
+        "model": model,
+        "messages": user_msgs,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if system:
+        kwargs["system"] = system
+    r = client.messages.create(**kwargs)
+    return r.content[0].text
+
+
+def chat_with_llm(
+    config: dict,
+    messages: list[dict],
+    temperature: float = 0.1,
+    max_tokens: int = 4096,
+) -> str:
+    """Route to Anthropic or OpenRouter based on config['llm_provider']."""
+    if config.get("llm_provider") == "anthropic":
+        return _chat_with_anthropic(config, messages, temperature, max_tokens)
+    return chat_with_fallback(_make_openrouter_client(config), config, messages, temperature, max_tokens)
 
 
 def chat_with_fallback(

--- a/job_hunt/scanner.py
+++ b/job_hunt/scanner.py
@@ -4,10 +4,9 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from openai import OpenAI
 from tinyfish import RateLimitError, TinyFish
 
-from job_hunt.llm_utils import chat_with_fallback
+from job_hunt.llm_utils import chat_with_llm
 from job_hunt.notifier import send_telegram
 
 STATE_FILE = Path("state/seen_jobs.json")
@@ -218,7 +217,7 @@ def fetch_job_details(tf: TinyFish, jobs: list[dict]) -> list[dict]:
     return enriched
 
 
-def score_jobs(llm: OpenAI, jobs: list[dict], resume: str, config: dict) -> list[dict]:
+def score_jobs(jobs: list[dict], resume: str, config: dict) -> list[dict]:
     if not jobs:
         return []
 
@@ -240,8 +239,8 @@ def score_jobs(llm: OpenAI, jobs: list[dict], resume: str, config: dict) -> list
     )
 
     try:
-        raw = chat_with_fallback(
-            llm, config,
+        raw = chat_with_llm(
+            config,
             messages=[{"role": "user", "content": prompt}],
             temperature=0.1,
         )
@@ -295,15 +294,6 @@ def run_scan(config: dict, companies: list[dict]) -> None:
         print(f"TinyFish init error: {e}")
         return
 
-    try:
-        llm = OpenAI(
-            api_key=config["openrouter_api_key"],
-            base_url="https://openrouter.ai/api/v1",
-        )
-    except Exception as e:
-        print(f"OpenRouter init error: {e}")
-        return
-
     resume_path = Path(config.get("candidate", {}).get("resume_path", "resume/YOUR_RESUME.md"))
     resume = resume_path.read_text()
     min_score = config.get("candidate", {}).get("min_score", 55)
@@ -331,7 +321,7 @@ def run_scan(config: dict, companies: list[dict]) -> None:
             try:
                 for i in range(0, len(new_jobs), 10):
                     batch = new_jobs[i : i + 10]
-                    batch_scored = score_jobs(llm, batch, resume, config)
+                    batch_scored = score_jobs(batch, resume, config)
                     scored.extend(batch_scored)
             except Exception as score_err:
                 print(f"  Scoring failed: {score_err}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0.0"]
+claude = ["anthropic>=0.30.0"]
 dev = ["pytest>=8.0", "ruff>=0.4"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "autopilot-jobs"
+name = "autopilot-jobhunt"
 version = "0.1.0"
 description = "AI-powered job scanner, scorer, and application drafter. Finds jobs while you sleep."
 readme = "README.md"
@@ -32,9 +32,9 @@ dev = ["pytest>=8.0", "ruff>=0.4"]
 autopilot = "job_hunt.main:main"
 
 [project.urls]
-Homepage = "https://github.com/tarunlnmiit/autopilot-jobs"
-Repository = "https://github.com/tarunlnmiit/autopilot-jobs"
-Issues = "https://github.com/tarunlnmiit/autopilot-jobs/issues"
+Homepage = "https://github.com/tarunlnmiit/autopilot-jobhunt"
+Repository = "https://github.com/tarunlnmiit/autopilot-jobhunt"
+Issues = "https://github.com/tarunlnmiit/autopilot-jobhunt/issues"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

- Add unified `chat_with_llm()` dispatcher routing to Anthropic or OpenRouter based on `config["llm_provider"]`
- Decouple `scanner.py` and `drafter.py` from direct OpenAI client creation — both now use `chat_with_llm`
- Add `claude = ["anthropic>=0.30.0"]` optional dependency in `pyproject.toml`
- Extend `config.example.json` and `.env.example` with Anthropic fields
- Document both standalone CLI and MCP usage modes in README and SETUP.md

## Test plan

- [ ] `ruff check job_hunt/` passes
- [ ] `from job_hunt.llm_utils import chat_with_llm` imports without error
- [ ] Calling `chat_with_llm({'llm_provider': 'anthropic'}, [...])` without `anthropic` SDK installed raises `ImportError` with helpful message
- [ ] `autopilot export` runs successfully with OpenRouter config

🤖 Generated with [Claude Code](https://claude.com/claude-code)