### PR TITLE
fix: dotenv override, placeholder guard, ruff F541 (v0.2.2)

### DIFF
--- a/job_hunt/main.py
+++ b/job_hunt/main.py
@@ -20,8 +20,19 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 
+_PLACEHOLDERS = {
+    "YOUR_TINYFISH_API_KEY", "your_tinyfish_api_key_here",
+    "YOUR_OPENROUTER_API_KEY", "your_openrouter_api_key_here",
+    "YOUR_ANTHROPIC_API_KEY", "your_anthropic_api_key_here",
+}
+
+
+def _is_placeholder(val: str) -> bool:
+    return val in _PLACEHOLDERS or val.startswith("YOUR_") or val.endswith("_HERE") or val.endswith("_here")
+
+
 def load_config() -> dict:
-    load_dotenv()
+    load_dotenv(dotenv_path=Path(".env"), override=True)
     p = Path("config.json")
     if not p.exists():
         sys.exit("config.json not found.\nRun 'autopilot init' to set up your working directory.")
@@ -42,6 +53,14 @@ def load_config() -> dict:
                 config[config_key] = [m.strip() for m in val.split(",")]
             else:
                 config[config_key] = val
+
+    tinyfish_key = config.get("tinyfish_api_key", "")
+    if not tinyfish_key or _is_placeholder(tinyfish_key):
+        sys.exit(
+            "TINYFISH_API_KEY not set.\n"
+            "Add it to your .env file: TINYFISH_API_KEY=sk-tinyfish-...\n"
+            "Get a key at https://agent.tinyfish.ai"
+        )
 
     tg_token = os.getenv("TELEGRAM_TOKEN")
     tg_chat_id = os.getenv("TELEGRAM_CHAT_ID")

--- a/job_hunt/scanner.py
+++ b/job_hunt/scanner.py
@@ -369,7 +369,7 @@ def run_scan(config: dict, companies: list[dict]) -> None:
         try:
             new_jobs = discover_job_urls(tf, company, seen_urls)
             if not new_jobs:
-                logger.info(f"  No new job URLs found")
+                logger.info("  No new job URLs found")
                 companies_scanned += 1
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autopilot-jobhunt"
-version = "0.2.1"
+version = "0.2.2"
 description = "AI-powered job scanner, scorer, and application drafter. Finds jobs while you sleep."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- `load_dotenv(override=True)` with explicit CWD path — `.env` real values now always win over stale shell env vars; fixes scanner using config.json placeholders instead of `.env` keys
- Placeholder guard in `load_config()` — exits immediately with actionable message if `TINYFISH_API_KEY` is unset or still a template value
- Remove redundant `f`-prefix on static string in `scanner.py` — fixes ruff `F541` CI failure

## Test plan
- [ ] Run `autopilot scan` with `.env` containing real keys — confirm keys loaded correctly
- [ ] Run `autopilot scan` with placeholder `TINYFISH_API_KEY` — confirm early exit with clear error
- [ ] CI ruff check passes (no F541)
- [ ] `pip install` from wheel, run `autopilot --help` and `autopilot init`