### PR TITLE
feat: add claude_cli LLM provider, bump to v0.3.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,14 @@ OPENROUTER_API_KEY="your_openrouter_api_key_here"
 OPENROUTER_MODEL="meta-llama/llama-3.3-70b-instruct:free"
 OPENROUTER_FALLBACK_MODELS="nvidia/nemotron-3-super-120b-a12b:free,google/gemma-4-31b-it:free,qwen/qwen3-coder:free"
 
-# Anthropic / Claude (optional — alternative to OpenRouter)
-# Set llm_provider=anthropic in config.json to use Claude instead of OpenRouter
+# Anthropic / Claude API (optional — alternative to OpenRouter, requires API key)
+# Set llm_provider=anthropic in config.json to use Anthropic API
 # ANTHROPIC_API_KEY="your_anthropic_api_key_here"
+
+# Claude Code CLI (optional — no API key needed, uses local claude auth)
+# Requires: Claude Code installed (https://claude.ai/code) + claude auth login
+# LLM_PROVIDER="claude_cli"
+# CLAUDE_CLI_MODEL=""   # empty = claude's default; or "sonnet", "opus", "haiku"
 
 # Telegram Notification (optional — create bot via @BotFather)
 TELEGRAM_TOKEN="your_telegram_bot_token_here"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ job_hunt/
   scanner.py    — TinyFish API job discovery + LLM scoring pipeline
   drafter.py    — cover letter + tailored resume bullet generation
   notifier.py   — Telegram notification sender (optional, graceful if unconfigured)
-  llm_utils.py  — OpenRouter wrapper with 4-model free-tier fallback chain
+  llm_utils.py  — LLM dispatch: OpenRouter (default), Anthropic API, or Claude Code CLI
   tools.py      — protocol-agnostic tool layer (wraps scanner/drafter/exporter)
   mcp_server.py — FastMCP server exposing scan_jobs, draft_application, export_jobs
   main.py       — CLI entry point (autopilot command)
@@ -59,6 +59,15 @@ job_hunt/
 - **"All LLM models failed":** all 4 models hit their daily quota — wait for midnight UTC reset, or add a small OpenRouter credit ($1–5) to remove the cap
 - **Multiple scans/day:** risks exhausting free-tier quota — run once nightly via cron
 - Check live per-model limits: [openrouter.ai/models](https://openrouter.ai/models)
+
+### Claude Code CLI (LLM backend — no API key needed)
+
+- **Cost:** uses your Claude subscription (Pro/Team/Enterprise)
+- **Setup:** `claude auth login` — no API key required
+- **Activate:** set `"llm_provider": "claude_cli"` in `config.json` or `LLM_PROVIDER=claude_cli` in `.env`
+- **Model:** set `"claude_cli_model": "sonnet"` (or `"opus"`, `"haiku"`) — empty = Claude's default
+- **Rate limits:** governed by your subscription tier, not a daily free quota
+- **Cron / MCP note:** subprocess inherits user session auth — verify with `claude --print "hi"` in the same shell context before scheduling
 
 ## MCP registration (Claude Code)
 

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ autopilot scan
 
 ### API keys needed
 
-| Service | Cost | Where to get it |
-|---|---|---|
-| **TinyFish** | **Free** — no credit card | [agent.tinyfish.ai](https://agent.tinyfish.ai) |
-| **OpenRouter** | **Free** — 4-model fallback chain | [openrouter.ai](https://openrouter.ai) |
-| **Telegram** | Free — optional | [@BotFather](https://t.me/BotFather) on Telegram |
+| Service | Cost | Required | Where to get it |
+|---|---|---|---|
+| **TinyFish** | **Free** — no credit card | Always | [agent.tinyfish.ai](https://agent.tinyfish.ai) |
+| **OpenRouter** | **Free** — 4-model fallback chain | Unless using Claude CLI / Anthropic | [openrouter.ai](https://openrouter.ai) |
+| **Telegram** | Free | Optional | [@BotFather](https://t.me/BotFather) on Telegram |
 
 ---
 
@@ -272,9 +272,30 @@ Uses a 4-model fallback chain — all free, no credit card needed:
 
 If one model hits its daily free-tier quota, the tool automatically tries the next. **Zero LLM cost by default.**
 
-### Alternative: Claude (Anthropic)
+### Alternative A: Claude Code CLI (no API key needed)
 
-If you have an Anthropic API key or Claude Pro:
+If you have [Claude Code](https://claude.ai/code) installed and authenticated, you can use it as the LLM backend — no separate API key required:
+
+In `config.json`:
+
+```json
+"llm_provider": "claude_cli"
+```
+
+Or via environment variable: `LLM_PROVIDER=claude_cli autopilot scan`
+
+Optionally set a model: `"claude_cli_model": "sonnet"` (or `"opus"`, `"haiku"`, empty = Claude's default).
+
+> **Note:** Requires the `claude` binary in your PATH. Verify with `claude --print "hi"` first.
+> The MCP server and cron jobs must run in an environment where your `claude` auth session is active.
+>
+> **Rate-limit note:** Each call loads your global Claude Code context (~25–30k tokens). A nightly scan
+> (5–15 LLM calls) burns significantly against your subscription's 7-day rate limit. Prefer OpenRouter
+> for nightly automation; use Claude CLI for occasional on-demand drafts.
+
+### Alternative B: Anthropic API
+
+If you have an Anthropic API key:
 
 ```bash
 pip install 'autopilot-jobhunt[claude]'

--- a/SETUP.md
+++ b/SETUP.md
@@ -70,10 +70,67 @@ A nightly scan uses approximately **5–15 LLM calls** (jobs are scored in batch
 
 ---
 
-### Claude / Anthropic (optional — alternative to OpenRouter)
+### Option B — Claude Code CLI (optional — no API key needed)
 
 <details>
-<summary>Use Claude as your LLM instead of OpenRouter — click to expand</summary>
+<summary>Use Claude Code CLI as your LLM — no API key required — click to expand</summary>
+
+If you have [Claude Code](https://claude.ai/code) installed and authenticated (Pro, Team, or Enterprise subscription), you can use it as the LLM backend without any API key.
+
+1. Install Claude Code: [claude.ai/code](https://claude.ai/code)
+2. Authenticate:
+   ```bash
+   claude auth login
+   ```
+3. Verify it works:
+   ```bash
+   claude --print "hi"
+   ```
+4. In `config.json`, set:
+   ```json
+   "llm_provider": "claude_cli"
+   ```
+5. Optionally set a model (empty string = Claude's default):
+   ```json
+   "claude_cli_model": "sonnet"
+   ```
+   Accepted values: `"sonnet"`, `"opus"`, `"haiku"`, or a full model ID like `"claude-sonnet-4-6"`.
+
+You can also switch provider via environment variable without editing config:
+```bash
+LLM_PROVIDER=claude_cli autopilot scan
+```
+
+> [!TIP]
+> Leave `openrouter_api_key` empty if using Claude CLI — the field is ignored when
+> `llm_provider` is set to `"claude_cli"`.
+
+> [!WARNING]
+> **Cron jobs and MCP server:** Both run as background processes. They inherit the shell
+> environment of the user who started them, so your `claude` auth session must be active
+> in that environment. Run `claude --print "hi"` from the same shell context (same user,
+> same session) before scheduling to confirm auth works there.
+
+> [!NOTE]
+> `temperature` and `max_tokens` are not configurable when using Claude CLI — the binary
+> doesn't expose these flags. The default model settings are used for all calls.
+
+> [!WARNING]
+> **Subscription rate-limit burn.** Each CLI call loads your global Claude Code context
+> (CLAUDE.md, rules, memory) — typically 25,000–30,000 tokens even for a short prompt. A
+> nightly scan makes 5–15 LLM calls, consuming that many large requests against your
+> subscription's 7-day rate limit. If you're already heavy on Claude Code usage, a full
+> scan may trigger a rate-limit warning or temporary slowdown. Prefer OpenRouter (default)
+> for nightly automation; use Claude CLI for occasional on-demand drafts or when testing.
+
+</details>
+
+---
+
+### Option C — Anthropic API (optional — alternative to OpenRouter)
+
+<details>
+<summary>Use Claude API with an Anthropic API key — click to expand</summary>
 
 If you have an Anthropic API key or Claude Pro, you can skip OpenRouter entirely.
 
@@ -94,7 +151,7 @@ Recommended models:
 - `claude-sonnet-4-6` — higher quality scores, higher cost
 
 > [!TIP]
-> Leave `openrouter_api_key` empty if using Claude — the field is ignored when
+> Leave `openrouter_api_key` empty if using the Anthropic API — the field is ignored when
 > `llm_provider` is set to `"anthropic"`.
 
 </details>
@@ -470,6 +527,8 @@ crontab -e   # delete the autopilot-jobhunt line
 |---|---|---|
 | `config.json not found` | Wrong working directory or `cwd` not set | Run `autopilot init` in your working dir, or add `"cwd"` to `~/.claude.json` — see Step 7c |
 | `All LLM models failed` | Wrong key, or all 4 models hit daily quota | Verify `OPENROUTER_API_KEY`; wait for midnight UTC reset |
+| `claude binary not found in PATH` | Claude CLI not installed or not on PATH | Install from [claude.ai/code](https://claude.ai/code); run `which claude` to verify |
+| `claude CLI exited 1` | Not authenticated | Run `claude auth login` then retry |
 | `autopilot: command not found` | pip install incomplete or wrong venv | Re-run `pip install -e '.[mcp]'` from repo directory |
 | No Telegram notification | Token not configured | Expected — scan still completes, results print to terminal |
 | Scan takes 30–90 min | Normal pacing for free tier | Let it run; use cron to automate |

--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,7 @@
   ],
   "anthropic_api_key": "YOUR_ANTHROPIC_API_KEY",
   "anthropic_model": "claude-haiku-4-5-20251001",
+  "claude_cli_model": "",
   "telegram": {
     "token": "YOUR_TELEGRAM_BOT_TOKEN",
     "chat_id": "YOUR_TELEGRAM_CHAT_ID"

--- a/job_hunt/data/config.example.json
+++ b/job_hunt/data/config.example.json
@@ -10,6 +10,7 @@
   ],
   "anthropic_api_key": "YOUR_ANTHROPIC_API_KEY",
   "anthropic_model": "claude-haiku-4-5-20251001",
+  "claude_cli_model": "",
   "telegram": {
     "token": "YOUR_TELEGRAM_BOT_TOKEN",
     "chat_id": "YOUR_TELEGRAM_CHAT_ID"

--- a/job_hunt/llm_utils.py
+++ b/job_hunt/llm_utils.py
@@ -1,4 +1,6 @@
+import json
 import os
+import subprocess
 import time
 
 from openai import OpenAI, RateLimitError
@@ -42,14 +44,70 @@ def _chat_with_anthropic(config: dict, messages: list[dict], temperature: float,
     return text
 
 
+def _chat_with_claude_cli(config: dict, messages: list[dict], temperature: float, max_tokens: int) -> str:
+    model = config.get("claude_cli_model", "")
+    logger.debug(f"LLM call → Claude CLI{' / ' + model if model else ''}")
+    t0 = time.time()
+
+    system = next((m["content"] for m in messages if m["role"] == "system"), None)
+    user_msgs = [m for m in messages if m["role"] != "system"]
+    prompt_text = "\n\n".join(f"{m['role'].upper()}:\n{m['content']}" for m in user_msgs)
+
+    # --strict-mcp-config suppresses all MCP servers in the subprocess; reduces ~27k context tokens
+    cmd = [
+        "claude", "--print", "--output-format", "json", "--tools", "",
+        "--mcp-config", '{"mcpServers":{}}', "--strict-mcp-config",
+        "--disable-slash-commands",
+    ]
+    if system:
+        cmd += ["--system-prompt", system]
+    if model:
+        cmd += ["--model", model]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt_text,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "claude binary not found in PATH.\n"
+            "Install Claude Code from https://claude.ai/code and run 'claude auth login'."
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("claude CLI timed out after 300s.")
+
+    if result.returncode != 0:
+        raise RuntimeError(f"claude CLI exited {result.returncode}: {result.stderr.strip()}")
+
+    try:
+        events = json.loads(result.stdout)
+        result_event = next((e for e in events if e.get("type") == "result"), None)
+        if result_event is None:
+            raise KeyError("no 'result' event found in output")
+        text = result_event["result"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise RuntimeError(f"claude CLI unexpected output ({e}): {result.stdout[:200]}")
+
+    elapsed = time.time() - t0
+    logger.debug(f"LLM response: {len(text)} chars in {elapsed:.1f}s via claude CLI")
+    return text
+
+
 def chat_with_llm(
     config: dict,
     messages: list[dict],
     temperature: float = 0.1,
     max_tokens: int = 4096,
 ) -> str:
-    if config.get("llm_provider") == "anthropic":
+    provider = config.get("llm_provider")
+    if provider == "anthropic":
         return _chat_with_anthropic(config, messages, temperature, max_tokens)
+    if provider == "claude_cli":
+        return _chat_with_claude_cli(config, messages, temperature, max_tokens)
     return chat_with_fallback(_make_openrouter_client(config), config, messages, temperature, max_tokens)
 
 

--- a/job_hunt/main.py
+++ b/job_hunt/main.py
@@ -40,9 +40,11 @@ def load_config() -> dict:
 
     env_mapping = {
         "TINYFISH_API_KEY": "tinyfish_api_key",
+        "LLM_PROVIDER": "llm_provider",
         "OPENROUTER_API_KEY": "openrouter_api_key",
         "OPENROUTER_MODEL": "openrouter_model",
         "OPENROUTER_FALLBACK_MODELS": "openrouter_fallback_models",
+        "CLAUDE_CLI_MODEL": "claude_cli_model",
     }
 
     for env_key, config_key in env_mapping.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autopilot-jobhunt"
-version = "0.2.2"
+version = "0.3.0"
 description = "AI-powered job scanner, scorer, and application drafter. Finds jobs while you sleep."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Add `claude_cli` as a third LLM backend — users with Claude Code CLI installed can use it without any API key (`llm_provider: "claude_cli"` in config or `LLM_PROVIDER=claude_cli` env var)
- Subprocess invocation uses `--print --output-format json --tools "" --strict-mcp-config` to prevent agentic loops and suppress MCP server autoloading (~25-30k token overhead per call)
- Add `claude_cli_model` config field (`"sonnet"`, `"opus"`, `"haiku"`, or full model ID; empty = CLI default)
- Add `LLM_PROVIDER` and `CLAUDE_CLI_MODEL` env overrides in `main.py`
- Update both `config.example.json` copies and `.env.example`
- Document subscription rate-limit burn in README and SETUP — recommends OpenRouter for nightly scans, Claude CLI for occasional drafts
- Bump version `0.2.2` → `0.3.0`

## Test plan

- [x] Smoke test: `chat_with_llm({'llm_provider': 'claude_cli'}, [...])` returns `['ok']`
- [x] Real scoring path: 2 jobs from `last_scan.json` → correct JSON array with all fields (`score`, `worth_applying`, `title`, `stack`, `location_remote`, `reason`)
- [x] `scanner.py`'s `raw.find("[") / raw.rfind("]")` extraction handles markdown code fences in CLI output
- [x] `ruff check` passes clean
- [x] Existing OpenRouter and Anthropic paths unaffected (dispatch unchanged for non-`claude_cli` providers)