### PR TITLE
fix: handle dict and list formats in claude CLI JSON output

### DIFF
--- a/job_hunt/llm_utils.py
+++ b/job_hunt/llm_utils.py
@@ -84,12 +84,19 @@ def _chat_with_claude_cli(config: dict, messages: list[dict], temperature: float
         raise RuntimeError(f"claude CLI exited {result.returncode}: {result.stderr.strip()}")
 
     try:
-        events = json.loads(result.stdout)
-        result_event = next((e for e in events if e.get("type") == "result"), None)
-        if result_event is None:
-            raise KeyError("no 'result' event found in output")
-        text = result_event["result"]
-    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        data = json.loads(result.stdout)
+        if isinstance(data, dict):
+            text = data.get("result")
+            if text is None:
+                raise KeyError("no 'result' field in output")
+        elif isinstance(data, list):
+            result_event = next((e for e in data if isinstance(e, dict) and e.get("type") == "result"), None)
+            if result_event is None:
+                raise KeyError("no 'result' event found in output")
+            text = result_event["result"]
+        else:
+            raise TypeError(f"unexpected output type: {type(data)}")
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as e:
         raise RuntimeError(f"claude CLI unexpected output ({e}): {result.stdout[:200]}")
 
     elapsed = time.time() - t0


### PR DESCRIPTION
## Summary

- Fixes `Scoring error: 'str' object has no attribute 'get'` when using `claude_cli` LLM provider
- Root cause: Claude CLI `--output-format json` can return a single result dict; the previous code only handled the array-of-events form. Iterating a dict yields string keys → `e.get("type")` raises `AttributeError` → not caught by the narrow `except (JSONDecodeError, KeyError, TypeError)` → bubbles up as a confusing scoring error
- Now handles both dict (current format) and list (legacy array-of-events) formats
- Also adds `AttributeError` to the except clause as a safety net

## Test plan

- [ ] Run `autopilot scan` with `"llm_provider": "claude_cli"` — scoring should complete without errors
- [ ] Confirm list-format path still works (existing behaviour unchanged)