### PR TITLE
Scan robustness + config/.env precedence fixes (v0.4.0)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -305,7 +305,8 @@ TELEGRAM_CHAT_ID=your_numeric_chat_id_here
 
 ## Step 6 — Verify setup
 
-Run a smoke test that loads your config but makes **no API calls**:
+Run a smoke test that makes **no API calls** and needs **no API keys** —
+`export` only reads local scan state:
 
 ```bash
 autopilot export
@@ -313,10 +314,13 @@ autopilot export
 
 ✅ **Expected output (before first scan):**
 ```
-No scan results found. Run 'autopilot scan' first.
+No scan found. Run: autopilot scan
 ```
 
-If you see this, your install is working correctly — config loads, CLI is on your PATH, everything is wired up. The message just means you haven't run a scan yet.
+If you see this, your install is working correctly — the CLI is on your PATH,
+bundled data files are in place, everything is wired up. The message just means
+you haven't run a scan yet. (You do **not** need to fill in any API keys for this
+check to pass.)
 
 **After your first scan**, `autopilot export` produces a CSV like this:
 

--- a/job_hunt/llm_utils.py
+++ b/job_hunt/llm_utils.py
@@ -9,11 +9,17 @@ from job_hunt.log import get_logger
 
 logger = get_logger()
 
+# Per-request timeout (seconds) for HTTP-based LLM providers. Without this the
+# openai/anthropic SDKs default to 600s, so a single stalled free-tier model can
+# freeze a scan for 10 minutes. claude_cli has its own subprocess timeout (300s).
+_LLM_REQUEST_TIMEOUT = 120.0
+
 
 def _make_openrouter_client(config: dict) -> OpenAI:
     return OpenAI(
         api_key=config.get("openrouter_api_key") or os.getenv("OPENROUTER_API_KEY"),
         base_url="https://openrouter.ai/api/v1",
+        timeout=_LLM_REQUEST_TIMEOUT,
     )
 
 
@@ -26,7 +32,7 @@ def _chat_with_anthropic(config: dict, messages: list[dict], temperature: float,
     model = config.get("anthropic_model", "claude-haiku-4-5-20251001")
     logger.debug(f"LLM call → Anthropic / {model}")
     t0 = time.time()
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.Anthropic(api_key=api_key, timeout=_LLM_REQUEST_TIMEOUT)
     system = next((m["content"] for m in messages if m["role"] == "system"), None)
     user_msgs = [m for m in messages if m["role"] != "system"]
     kwargs: dict = {

--- a/job_hunt/log.py
+++ b/job_hunt/log.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -15,8 +16,11 @@ def get_logger(name: str = "autopilot") -> logging.Logger:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
+    # Console level is INFO by default; set LOG_LEVEL=DEBUG for full per-URL/per-job
+    # detail on stdout (the scan.log file always captures DEBUG regardless).
+    console_level = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO)
     console = logging.StreamHandler(sys.stdout)
-    console.setLevel(logging.INFO)
+    console.setLevel(console_level)
     console.setFormatter(fmt)
     logger.addHandler(console)
 

--- a/job_hunt/main.py
+++ b/job_hunt/main.py
@@ -30,6 +30,16 @@ def _is_placeholder(val: str) -> bool:
     return val in _PLACEHOLDERS or val.startswith("YOUR_") or val.endswith("_HERE") or val.endswith("_here")
 
 
+def _use_env(val: str | None) -> bool:
+    """An env var overrides config.json only if it's set and not a placeholder.
+
+    Without the placeholder guard, the default `.env` template (which `autopilot
+    init` writes with `your_..._here` values) would clobber real keys in
+    config.json — the classic "config.json and .env don't compose" bug.
+    """
+    return bool(val) and not _is_placeholder(val)
+
+
 def load_config() -> dict:
     load_dotenv(dotenv_path=Path(".env"), override=True)
     p = Path("config.json")
@@ -45,11 +55,13 @@ def load_config() -> dict:
         "OPENROUTER_MODEL": "openrouter_model",
         "OPENROUTER_FALLBACK_MODELS": "openrouter_fallback_models",
         "CLAUDE_CLI_MODEL": "claude_cli_model",
+        "ANTHROPIC_API_KEY": "anthropic_api_key",
+        "ANTHROPIC_MODEL": "anthropic_model",
     }
 
     for env_key, config_key in env_mapping.items():
         val = os.getenv(env_key)
-        if val:
+        if _use_env(val):
             if env_key == "OPENROUTER_FALLBACK_MODELS":
                 config[config_key] = [m.strip() for m in val.split(",")]
             else:
@@ -63,8 +75,8 @@ def load_config() -> dict:
             "Get a key at https://agent.tinyfish.ai"
         )
 
-    tg_token = os.getenv("TELEGRAM_TOKEN")
-    tg_chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    tg_token = os.getenv("TELEGRAM_TOKEN") if _use_env(os.getenv("TELEGRAM_TOKEN")) else None
+    tg_chat_id = os.getenv("TELEGRAM_CHAT_ID") if _use_env(os.getenv("TELEGRAM_CHAT_ID")) else None
     if tg_token or tg_chat_id:
         if "telegram" not in config:
             config["telegram"] = {}
@@ -154,6 +166,25 @@ def _job_to_row(j: dict) -> dict:
     }
 
 
+def _parse_export_args(argv: list[str]) -> tuple[int, int]:
+    """Parse --min / --days flags for the export command. No API keys required."""
+    min_score = 0
+    days = 0
+    if "--min" in argv:
+        idx = argv.index("--min")
+        try:
+            min_score = int(argv[idx + 1])
+        except (IndexError, ValueError):
+            sys.exit("--min requires an integer, e.g. --min 60")
+    if "--days" in argv:
+        idx = argv.index("--days")
+        try:
+            days = int(argv[idx + 1])
+        except (IndexError, ValueError):
+            sys.exit("--days requires an integer, e.g. --days 7")
+    return min_score, days
+
+
 def export_jobs(min_score: int = 0, days: int = 0) -> None:
     if days > 0:
         if not JOB_HISTORY_FILE.exists():
@@ -203,6 +234,12 @@ def main() -> None:
         init_project()
         return
 
+    # export reads local scan state only — no API keys needed, so skip load_config()
+    if cmd == "export":
+        min_score, days = _parse_export_args(sys.argv)
+        export_jobs(min_score=min_score, days=days)
+        return
+
     config = load_config()
 
     if cmd == "scan":
@@ -214,23 +251,6 @@ def main() -> None:
             sys.exit("Usage: autopilot draft #N  or  autopilot draft URL")
         from job_hunt.drafter import draft_application
         draft_application(config, sys.argv[2])
-
-    elif cmd == "export":
-        min_score = 0
-        days = 0
-        if "--min" in sys.argv:
-            idx = sys.argv.index("--min")
-            try:
-                min_score = int(sys.argv[idx + 1])
-            except (IndexError, ValueError):
-                sys.exit("--min requires an integer, e.g. --min 60")
-        if "--days" in sys.argv:
-            idx = sys.argv.index("--days")
-            try:
-                days = int(sys.argv[idx + 1])
-            except (IndexError, ValueError):
-                sys.exit("--days requires an integer, e.g. --days 7")
-        export_jobs(min_score=min_score, days=days)
 
     else:
         sys.exit(f"Unknown command: {cmd}\nUse: scan | draft | export")

--- a/job_hunt/scanner.py
+++ b/job_hunt/scanner.py
@@ -339,7 +339,13 @@ def run_scan(config: dict, companies: list[dict]) -> None:
     logger.info(f"=== Scan started — {total} companies to check ===")
     logger.info(f"Candidate: {config.get('candidate', {}).get('name', 'unknown')}")
     logger.info(f"Min score: {config.get('candidate', {}).get('min_score', 55)} | Top N: {config.get('candidate', {}).get('top_n', 5)}")
-    logger.info(f"LLM provider: {config.get('llm_provider', 'openrouter')} | Model: {config.get('openrouter_model', 'default')}")
+    provider = config.get("llm_provider") or "openrouter"
+    model_by_provider = {
+        "openrouter": config.get("openrouter_model", "default"),
+        "anthropic": config.get("anthropic_model", "default"),
+        "claude_cli": config.get("claude_cli_model") or "claude default",
+    }
+    logger.info(f"LLM provider: {provider} | Model: {model_by_provider.get(provider, 'default')}")
 
     try:
         tf = TinyFish(api_key=config["tinyfish_api_key"])
@@ -451,28 +457,32 @@ def run_scan(config: dict, companies: list[dict]) -> None:
     tg = config.get("telegram", {})
     telegram_configured = bool(tg.get("token") and tg.get("chat_id"))
 
+    # Always persist results to CSV when there are scored jobs — this is the
+    # durable record regardless of whether Telegram is configured.
+    csv_path = _export_to_csv(all_scored_jobs, "scan results") if all_scored_jobs else None
+
     if errors and telegram_configured:
         error_msg = f"<b>Job Hunt Errors — {date_str}</b>\n" + "\n".join(errors)
         send_telegram(tg["token"], tg["chat_id"], error_msg)
 
     if not top_jobs:
         logger.info("No matching jobs found today.")
-        msg = f"<b>Job Hunt — {date_str}</b>\nNo new matches today."
         if telegram_configured:
+            msg = f"<b>Job Hunt — {date_str}</b>\nNo new matches today."
             send_telegram(tg["token"], tg["chat_id"], msg)
         return
 
     msg = format_telegram_message(top_jobs, date_str)
     logger.info("\n" + msg)
 
+    # Telegram is an optional notification on top of the CSV. When it's not
+    # configured we simply skip it — no error, the CSV already holds the results.
     if telegram_configured:
         sent = send_telegram(tg["token"], tg["chat_id"], msg)
         if sent:
-            logger.info("Telegram notification sent.")
+            logger.info(f"Telegram notification sent. Results also saved to CSV: {csv_path}")
         else:
-            logger.warning("Telegram send failed — exporting results to CSV as fallback.")
-            _export_to_csv(all_scored_jobs, "scan results")
+            logger.warning(f"Telegram send failed — results saved to CSV: {csv_path}")
     else:
-        logger.info("Telegram not configured — exporting results to CSV instead.")
-        _export_to_csv(all_scored_jobs, "scan results")
+        logger.info(f"Telegram not configured — results saved to CSV: {csv_path}")
         logger.info("Add telegram.token and telegram.chat_id to config.json to enable notifications.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autopilot-jobhunt"
-version = "0.3.1"
+version = "0.4.0"
 description = "AI-powered job scanner, scorer, and application drafter. Finds jobs while you sleep."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_config_precedence.py
+++ b/tests/test_config_precedence.py
@@ -1,0 +1,65 @@
+"""config.json + .env composition.
+
+Rule: an env var overrides config.json only when it's set AND not a placeholder.
+The default `.env` template written by `autopilot init` is full of `your_..._here`
+placeholders — those must never clobber real values in config.json.
+"""
+import json
+
+import pytest
+
+from job_hunt import main
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # Start from a clean env so the host shell's keys don't leak into assertions.
+    for k in ("TINYFISH_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY",
+              "ANTHROPIC_MODEL", "TELEGRAM_TOKEN", "TELEGRAM_CHAT_ID"):
+        monkeypatch.delenv(k, raising=False)
+    return tmp_path
+
+
+def _write_config(workdir, **overrides):
+    cfg = {"tinyfish_api_key": "sk-real-config-key"}
+    cfg.update(overrides)
+    (workdir / "config.json").write_text(json.dumps(cfg))
+
+
+def test_placeholder_env_does_not_override_real_config(workdir, monkeypatch):
+    _write_config(workdir, openrouter_api_key="sk-or-real-config")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "your_openrouter_api_key_here")
+
+    cfg = main.load_config()
+
+    assert cfg["openrouter_api_key"] == "sk-or-real-config"
+
+
+def test_real_env_overrides_config(workdir, monkeypatch):
+    _write_config(workdir, openrouter_api_key="sk-or-from-config")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-from-env")
+
+    cfg = main.load_config()
+
+    assert cfg["openrouter_api_key"] == "sk-or-from-env"
+
+
+def test_placeholder_tinyfish_env_does_not_break_real_config_key(workdir, monkeypatch):
+    """The exact 'config.json and .env don't compose' bug: real key in config,
+    placeholder in .env — must not exit with 'TINYFISH_API_KEY not set'."""
+    _write_config(workdir)  # tinyfish_api_key = sk-real-config-key
+    monkeypatch.setenv("TINYFISH_API_KEY", "YOUR_TINYFISH_API_KEY")
+
+    cfg = main.load_config()  # must not SystemExit
+
+    assert cfg["tinyfish_api_key"] == "sk-real-config-key"
+
+
+def test_anthropic_key_bridged_from_env(workdir, monkeypatch):
+    _write_config(workdir)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real")
+
+    cfg = main.load_config()
+
+    assert cfg["anthropic_api_key"] == "sk-ant-real"

--- a/tests/test_export_smoke.py
+++ b/tests/test_export_smoke.py
@@ -1,0 +1,56 @@
+"""Smoke tests for `autopilot export` — must work with no API keys.
+
+Regression guard: export reads local scan state only. It must NOT call
+load_config() or require TINYFISH_API_KEY (the documented Step 6 smoke test).
+"""
+import json
+import os
+
+import pytest
+
+from job_hunt import main
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    """Run inside an empty working dir with no config.json and no env keys."""
+    monkeypatch.chdir(tmp_path)
+    for key in ("TINYFISH_API_KEY", "OPENROUTER_API_KEY", "LLM_PROVIDER"):
+        monkeypatch.delenv(key, raising=False)
+    return tmp_path
+
+
+def test_export_without_keys_reports_no_scan(workdir, monkeypatch, capsys):
+    """No keys, no config, no scan state → friendly 'no scan' message, not a key error."""
+    monkeypatch.setattr("sys.argv", ["autopilot", "export"])
+
+    with pytest.raises(SystemExit) as exc:
+        main.main()
+
+    out = capsys.readouterr().out
+    assert "No scan found. Run: autopilot scan" in str(exc.value) + out
+    assert "TINYFISH_API_KEY" not in str(exc.value)
+
+
+def test_export_reads_last_scan(workdir, monkeypatch, capsys):
+    """With a last_scan.json present, export writes a CSV — still no keys needed."""
+    state = workdir / "state"
+    state.mkdir()
+    (state / "last_scan.json").write_text(
+        json.dumps(
+            [{"company": "Acme", "title": "ML Engineer", "url": "https://x/jobs/1", "score": 90}]
+        )
+    )
+    monkeypatch.setattr("sys.argv", ["autopilot", "export"])
+
+    main.main()
+
+    out = capsys.readouterr().out
+    assert "Exported 1 jobs" in out
+    assert (workdir / "output").exists()
+
+
+def test_parse_export_args():
+    assert main._parse_export_args(["autopilot", "export"]) == (0, 0)
+    assert main._parse_export_args(["autopilot", "export", "--min", "70"]) == (70, 0)
+    assert main._parse_export_args(["autopilot", "export", "--days", "7", "--min", "60"]) == (60, 7)

--- a/tests/test_scan_output.py
+++ b/tests/test_scan_output.py
@@ -1,0 +1,72 @@
+"""run_scan output behavior — CSV is always written; Telegram is optional.
+
+- No Telegram configured  -> CSV saved, send_telegram NOT called, no error.
+- Telegram configured      -> CSV saved AND send_telegram called.
+"""
+import csv
+
+import pytest
+
+from job_hunt import scanner
+
+
+@pytest.fixture
+def scan_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    resume = tmp_path / "resume.md"
+    resume.write_text("Senior ML/AI engineer, 10 YOE.")
+
+    # Stub the whole discovery/fetch/score pipeline so the test is deterministic
+    # and makes no network or LLM calls.
+    monkeypatch.setattr(scanner, "TinyFish", lambda **_: object())
+    monkeypatch.setattr(scanner, "discover_job_urls", lambda tf, co, seen: [
+        {"url": "https://x.co/jobs/1", "title": "ML Engineer",
+         "company": co["name"], "location": co["location"], "region": co["region"]},
+    ])
+    monkeypatch.setattr(scanner, "fetch_job_details", lambda tf, jobs: jobs)
+    monkeypatch.setattr(scanner, "score_jobs", lambda jobs, resume, config: [
+        {**jobs[0], "score": 90, "extracted_title": "ML Engineer",
+         "stack": "Python, LLMs", "location_remote": "Remote", "reason": "Strong fit"},
+    ])
+
+    calls = []
+    monkeypatch.setattr(scanner, "send_telegram",
+                        lambda token, chat, msg: calls.append((token, chat, msg)) or True)
+
+    base_config = {
+        "tinyfish_api_key": "sk-x",
+        "candidate": {"name": "Tarun", "resume_path": str(resume), "min_score": 40, "top_n": 5},
+    }
+    companies = [{"name": "Acme", "careers_url": "https://x.co", "search_domain": "x.co",
+                  "location": "Berlin", "region": "EU"}]
+    return tmp_path, base_config, companies, calls
+
+
+def _read_csv(tmp_path):
+    files = list((tmp_path / "output").glob("*.csv"))
+    assert files, "expected a CSV file in output/"
+    with files[0].open() as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_no_telegram_saves_csv_and_does_not_notify(scan_env):
+    tmp_path, config, companies, calls = scan_env  # no 'telegram' key
+
+    scanner.run_scan(config, companies)
+
+    rows = _read_csv(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["Company"] == "Acme"
+    assert calls == []  # Telegram never invoked, no error raised
+
+
+def test_telegram_configured_saves_csv_and_notifies(scan_env):
+    tmp_path, config, companies, calls = scan_env
+    config = {**config, "telegram": {"token": "bot-token", "chat_id": "123"}}
+
+    scanner.run_scan(config, companies)
+
+    rows = _read_csv(tmp_path)
+    assert len(rows) == 1                  # CSV still written
+    assert len(calls) == 1                 # AND Telegram sent
+    assert calls[0][0] == "bot-token"


### PR DESCRIPTION
## Summary
Hardening pass on setup/scan reliability, found while testing a fresh-machine install.

### Fixes
- **config.json / .env precedence**: `.env` now overrides config **only when set and not a placeholder**. The default `init` `.env` template (`your_..._here`) previously clobbered real keys in config.json → spurious `TINYFISH_API_KEY not set`. Also bridges `ANTHROPIC_API_KEY`/`ANTHROPIC_MODEL` (never mapped before).
- **`autopilot export` required a key**: it reads local scan state only; now dispatched before `load_config()`, needs no key.
- **LLM request timeout**: OpenRouter/Anthropic had the SDK 600s default → a stalled free model froze scans ~10 min. Now 120s, falls through to next model.

### Behavior change
- **CSV always saved**: every scan with results writes a CSV regardless of Telegram. Configured → CSV **and** Telegram message; not configured → CSV only, no error. Previously CSV was a fallback only.

### DX
- `LOG_LEVEL=DEBUG` surfaces per-job detail on stdout.
- Provider-aware startup log line.
- Corrected SETUP.md Step 6 smoke test.

### Tests
9 tests (new `tests/`): config precedence (4), scan output both Telegram paths (2), keyless export (3). All green.

### Verified live
Helsing scan via claude_cli: 7/10 matched, CSV written, no-Telegram path confirmed (no send, no error).