### PR TITLE
feat: config-driven job discovery search query (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ reconstructed from git history.
 
 ## [Unreleased]
 
+## [0.4.4] — 2026-07-09
+
+### Added
+- Job discovery search query is now config-driven: `candidate.search_seniority`
+  / `candidate.search_keywords` in `config.json` shape the `site:<domain>`
+  query sent to TinyFish per company. Empty/absent falls back to the previous
+  hardcoded senior/staff ML/DS terms, so existing configs behave identically.
+  Closes #24.
+
+### Fixed
+- `job_hunt/__init__.py` `__version__` re-synced with `pyproject.toml` (had
+  drifted to a stale `0.4.1` across the last two releases).
+
 ## [0.4.3] — 2026-07-05
 
 ### Added

--- a/SETUP.md
+++ b/SETUP.md
@@ -248,11 +248,23 @@ Open `config.json` and fill in the `candidate` section. Here's what each field c
     //          ↑ positive signal — jobs matching this score higher
     "not_suitable": "Junior roles, pure front-end, no-ML SWE",
     //               ↑ negative filter — jobs matching this score lower
+    "search_seniority": "junior OR entry OR associate",
+    //                   ↑ optional — shapes job DISCOVERY (the search query itself),
+    //                     not scoring. Empty/absent falls back to
+    //                     "senior OR staff OR principal OR lead".
+    "search_keywords": "\"full stack developer\" OR \"react developer\"",
+    //                  ↑ optional — same discovery mechanism. Empty/absent falls
+    //                    back to the default ML/DS role terms.
     "min_score": 65,   // jobs below this threshold are not saved or drafted
     "top_n": 5         // how many top matches to include in Telegram notification
   }
 }
 ```
+
+> `profile` / `seeking` / `not_suitable` only affect scoring — they never change what
+> gets searched for. If your profile doesn't match the default senior ML/DS search
+> terms, set `search_seniority` / `search_keywords` too, or discovery keeps finding
+> jobs that can't score well regardless of your resume.
 
 > [!WARNING]
 > `config.json` is gitignored — it will **never** be accidentally committed to git.

--- a/config.example.json
+++ b/config.example.json
@@ -22,6 +22,8 @@
     "seeking": "Remote-friendly or relocation to EU / NA / APAC",
     "not_suitable": "Junior roles, pure SWE with no ML, non-technical management",
     "relocation_note": "",
+    "search_seniority": "",
+    "search_keywords": "",
     "min_score": 60,
     "top_n": 5
   }

--- a/docs/04-companies-and-scanning.md
+++ b/docs/04-companies-and-scanning.md
@@ -31,7 +31,9 @@ faster.
 
 1. **Discover** — fetch `careers_url`, extract direct job links + ATS listing pages
    (Greenhouse, Lever, Workday, SmartRecruiters, Ashby), then expand ATS pages. Also
-   runs a `site:<search_domain>` query for senior/staff ML/AI roles.
+   runs a `site:<search_domain>` query built from `candidate.search_seniority` /
+   `search_keywords` (defaults to senior/staff ML/AI roles if unset) — see
+   [07 — Config & scoring](07-config-and-scoring.md).
 2. **Deduplicate** — URLs already seen (tracked in `state/seen_jobs.json`) are skipped,
    so each scan surfaces only *new* postings.
 3. **Fetch details** — pull each job page's content (first ~3000 chars).

--- a/docs/07-config-and-scoring.md
+++ b/docs/07-config-and-scoring.md
@@ -25,11 +25,25 @@ The scoring quality depends on this section — the LLM reads it plus your full 
     "profile": "8 YOE ML Engineer. Python, LLMs, AWS, MLOps.",
     "seeking": "Remote EU or NA roles, open to relocation",   // positive signal — scores higher
     "not_suitable": "Junior roles, pure front-end, no-ML SWE", // negative filter — scores lower
+    "search_seniority": "junior OR entry OR associate",
+    //                   ↑ optional — drives job DISCOVERY (the search query itself),
+    //                     not scoring. Empty/absent falls back to "senior OR staff
+    //                     OR principal OR lead".
+    "search_keywords": "\"full stack developer\" OR \"react developer\"",
+    //                  ↑ optional — same discovery mechanism. Empty/absent falls back
+    //                    to the default ML/DS role terms below.
     "min_score": 65,   // jobs below this are not saved or drafted
     "top_n": 5         // how many top matches go in the Telegram notification
   }
 }
 ```
+
+`profile` / `seeking` / `not_suitable` only affect **scoring** (how a discovered job
+is judged) — they never change what gets searched for. `search_seniority` /
+`search_keywords` are the only fields that shape **discovery** (the `site:` search
+query sent to TinyFish). If your profile doesn't match the default senior ML/DS
+search terms, set these two fields or you'll mostly discover jobs that can't score
+well regardless of your resume.
 
 ## Your resume
 

--- a/job_hunt/__init__.py
+++ b/job_hunt/__init__.py
@@ -1,3 +1,3 @@
 """autopilot-jobs: AI-powered job scanner, scorer, and application drafter."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.4"

--- a/job_hunt/scanner.py
+++ b/job_hunt/scanner.py
@@ -36,11 +36,17 @@ ATS_LISTING_RE = re.compile(
     re.IGNORECASE,
 )
 
-SEARCH_QUERY = (
-    'site:{domain} (senior OR staff OR principal OR lead) '
-    '("data scientist" OR "ML engineer" OR "machine learning engineer" '
-    'OR "AI engineer" OR MLOps OR "deep learning")'
+DEFAULT_SEARCH_SENIORITY = "senior OR staff OR principal OR lead"
+DEFAULT_SEARCH_KEYWORDS = (
+    '"data scientist" OR "ML engineer" OR "machine learning engineer" '
+    'OR "AI engineer" OR MLOps OR "deep learning"'
 )
+
+
+def build_search_query(domain: str, candidate: dict) -> str:
+    seniority = candidate.get("search_seniority") or DEFAULT_SEARCH_SENIORITY
+    keywords = candidate.get("search_keywords") or DEFAULT_SEARCH_KEYWORDS
+    return f'site:{domain} ({seniority}) ({keywords})'
 
 SCORE_PROMPT = """You are evaluating job postings for a candidate. Output ONLY a JSON array, no other text.
 
@@ -140,7 +146,9 @@ def _fetch_links(tf: TinyFish, urls: list[str]) -> dict[str, list[str]]:
     return result
 
 
-def discover_job_urls(tf: TinyFish, company: dict, seen_urls: set) -> list[dict]:
+def discover_job_urls(
+    tf: TinyFish, company: dict, seen_urls: set, candidate: dict | None = None
+) -> list[dict]:
     found_urls: set[str] = set()
 
     logger.debug(f"  [{company['name']}] Fetching careers page: {company['careers_url']}")
@@ -163,7 +171,7 @@ def discover_job_urls(tf: TinyFish, company: dict, seen_urls: set) -> list[dict]
                         ats_jobs += 1
             logger.debug(f"  [{company['name']}] ATS expansion: {ats_jobs} additional job links")
 
-    query = SEARCH_QUERY.format(domain=company["search_domain"])
+    query = build_search_query(company["search_domain"], candidate or {})
     logger.debug(f"  [{company['name']}] Search query: {query}")
     for attempt in range(2):
         try:
@@ -373,7 +381,7 @@ def run_scan(config: dict, companies: list[dict]) -> None:
     for idx, company in enumerate(companies, 1):
         logger.info(f"[{idx}/{total}] Scanning {company['name']}...")
         try:
-            new_jobs = discover_job_urls(tf, company, seen_urls)
+            new_jobs = discover_job_urls(tf, company, seen_urls, config.get("candidate", {}))
             if not new_jobs:
                 logger.info("  No new job URLs found")
                 companies_scanned += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autopilot-jobhunt"
-version = "0.4.3"
+version = "0.4.4"
 description = "AI-powered job scanner, scorer, and application drafter. Finds jobs while you sleep."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_scan_output.py
+++ b/tests/test_scan_output.py
@@ -19,7 +19,7 @@ def scan_env(tmp_path, monkeypatch):
     # Stub the whole discovery/fetch/score pipeline so the test is deterministic
     # and makes no network or LLM calls.
     monkeypatch.setattr(scanner, "TinyFish", lambda **_: object())
-    monkeypatch.setattr(scanner, "discover_job_urls", lambda tf, co, seen: [
+    monkeypatch.setattr(scanner, "discover_job_urls", lambda tf, co, seen, cand=None: [
         {"url": "https://x.co/jobs/1", "title": "ML Engineer",
          "company": co["name"], "location": co["location"], "region": co["region"]},
     ])

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -25,6 +25,34 @@ def test_is_ats_listing():
     assert not scanner.is_ats_listing("https://x.co/careers")
 
 
+def test_build_search_query_defaults():
+    expected = (
+        'site:x.co (senior OR staff OR principal OR lead) '
+        '("data scientist" OR "ML engineer" OR "machine learning engineer" '
+        'OR "AI engineer" OR MLOps OR "deep learning")'
+    )
+    assert scanner.build_search_query("x.co", {}) == expected
+
+
+def test_build_search_query_empty_string_fields_fall_back_to_defaults():
+    same_as_absent = scanner.build_search_query("x.co", {})
+    out = scanner.build_search_query(
+        "x.co", {"search_seniority": "", "search_keywords": ""}
+    )
+    assert out == same_as_absent
+
+
+def test_build_search_query_custom_fields():
+    out = scanner.build_search_query(
+        "x.co",
+        {
+            "search_seniority": "junior OR entry",
+            "search_keywords": '"full stack developer" OR "react developer"',
+        },
+    )
+    assert out == 'site:x.co (junior OR entry) ("full stack developer" OR "react developer")'
+
+
 def test_build_candidate_profile():
     cfg = {"candidate": {"name": "Ada", "profile": "ML eng", "seeking": "remote",
                          "not_suitable": "junior"}}
@@ -140,7 +168,7 @@ def scan_setup(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "resume.md").write_text("Senior ML engineer, 10 YOE.")
     monkeypatch.setattr(scanner, "TinyFish", lambda **_: object())
-    monkeypatch.setattr(scanner, "discover_job_urls", lambda tf, co, seen: [
+    monkeypatch.setattr(scanner, "discover_job_urls", lambda tf, co, seen, cand=None: [
         {"url": "https://x.co/jobs/1", "title": "MLE", "company": co["name"],
          "location": co["location"], "region": co["region"]}])
     monkeypatch.setattr(scanner, "fetch_job_details", lambda tf, jobs: jobs)


### PR DESCRIPTION
## Summary
- `SEARCH_QUERY` hardcoded senior DS/ML/AI terms for every company's TinyFish search — misaligned with `score_jobs()`, which already reads `candidate.profile`/`seeking`/`not_suitable` but never shaped discovery. A junior full-stack candidate's scan would only ever surface senior ML/DS roles.
- Adds `build_search_query()` + `candidate.search_seniority` / `candidate.search_keywords` config fields. Defaults (empty/absent) reproduce today's exact query string — verified byte-identical.
- Syncs `job_hunt/__init__.py` `__version__` (drifted to stale `0.4.1` across the last two releases) and bumps to `0.4.4`.
- Docs updated: `SETUP.md`, `docs/07-config-and-scoring.md` (new fields + discovery-vs-scoring distinction), `docs/04-companies-and-scanning.md` (stale "senior/staff ML/AI" claim corrected).

## Test plan
- [x] `pytest tests/ -q` — 82/82 passing
- [x] `build_search_query("x.co", {})` confirmed byte-identical to old hardcoded `SEARCH_QUERY.format(domain="x.co")`
- [x] New tests cover: defaults, custom fields, and empty-string fields falling back to defaults (guards the `or`-vs-`.get` fallback logic)

Fixes #24