### PR TITLE
fix(ci): trigger workflow on version tags so publish job actually runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- `on.push` only listed `branches: [main]`, so pushing a `v*` tag fired **zero** workflow runs. The `publish` job's `if: startsWith(github.ref, 'refs/tags/v')` was unreachable — confirmed by checking Actions history: no run has ever been tag-triggered, yet 0.1.0-0.4.4 are all live on PyPI (published manually via twine each time).
- Adds `tags: ["v*"]` to the push trigger so a version tag actually runs `lint-and-test` → `publish`.

## Caveat
- This makes the trigger fire. Whether the `publish` step itself succeeds depends on PyPI trusted-publishing (OIDC) being configured for this repo/workflow on PyPI's side — that's not verifiable from the repo and untested here (re-testing against an already-published version would just get a "file already exists" rejection). Next real version bump will be the first live test of the full automated path; manual twine remains the fallback if it fails.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] First tag pushed after this merges — confirm `publish` job actually runs and check PyPI trusted-publisher config if it fails